### PR TITLE
Replace Dema Therese with Atta in ps3_pair-1.qmd

### DIFF
--- a/ps3_pair-1.qmd
+++ b/ps3_pair-1.qmd
@@ -1,6 +1,6 @@
 ---
 title: "30538 Problem Set 3: git pair"
-author: "Dema Therese"
+author: "Attaullah Abbasi"
 format: 
   pdf:
     keep-tex: true


### PR DESCRIPTION
This pull request replaces "Dema Therese" with "Atta" in the ps3_pair-1.qmd file as part of the merge conflict practice.
